### PR TITLE
Fix ibc grace period test

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,6 @@ github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/decentrio/rollup-e2e-testing v0.0.0-20240217042554-3b5f78dba876 h1:09ApxSVYDJhdkfENKoOOOZDVo9leMbMuLPiEGHdC9TQ=
-github.com/decentrio/rollup-e2e-testing v0.0.0-20240217042554-3b5f78dba876/go.mod h1:Hy/8P41OEKrlAatPG5NcD/BOWTa2s+laECwpZpmA9f0=
 github.com/decentrio/rollup-e2e-testing v0.0.0-20240226065125-246da844cabf h1:yx8AVPUPphUcQxwxD2OVvJCitiRXr0SxnhNV0BXvoWY=
 github.com/decentrio/rollup-e2e-testing v0.0.0-20240226065125-246da844cabf/go.mod h1:Hy/8P41OEKrlAatPG5NcD/BOWTa2s+laECwpZpmA9f0=
 github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=

--- a/tests/ibc_grace_period_test.go
+++ b/tests/ibc_grace_period_test.go
@@ -8,6 +8,8 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
 	test "github.com/decentrio/rollup-e2e-testing"
 	"github.com/decentrio/rollup-e2e-testing/cosmos"
+	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
+	"github.com/decentrio/rollup-e2e-testing/cosmos/rollapp/dym_rollapp"
 	"github.com/decentrio/rollup-e2e-testing/ibc"
 	"github.com/decentrio/rollup-e2e-testing/relayer"
 	"github.com/decentrio/rollup-e2e-testing/testreporter"
@@ -43,11 +45,11 @@ func TestIBCGracePeriodCompliance(t *testing.T) {
 	numHubFullNodes := 1
 	numRollAppFn := 0
 	numRollAppVals := 1
-	cf := cosmos.NewBuiltinChainFactory(zaptest.NewLogger(t), []*cosmos.ChainSpec{
+	cf := test.NewBuiltinChainFactory(zaptest.NewLogger(t), []*test.ChainSpec{
 		{
 			Name: "rollapp1",
 			ChainConfig: ibc.ChainConfig{
-				Type:                "rollapp",
+				Type:                "rollapp-dym",
 				Name:                "rollapp-temp",
 				ChainID:             "demo-dymension-rollapp",
 				Images:              []ibc.DockerImage{rollappImage},
@@ -68,7 +70,7 @@ func TestIBCGracePeriodCompliance(t *testing.T) {
 		{
 			Name: "dymension-hub",
 			ChainConfig: ibc.ChainConfig{
-				Type:                "hub",
+				Type:                "hub-dym",
 				Name:                "dymension",
 				ChainID:             "dymension_100-1",
 				Images:              []ibc.DockerImage{dymensionImage},
@@ -93,19 +95,18 @@ func TestIBCGracePeriodCompliance(t *testing.T) {
 	chains, err := cf.Chains(t.Name())
 	require.NoError(t, err)
 
-	rollapp1 := chains[0].(*cosmos.CosmosChain)
-	dymension := chains[1].(*cosmos.CosmosChain)
+	rollapp1 := chains[0].(*dym_rollapp.DymRollApp)
+	dymension := chains[1].(*dym_hub.DymHub)
 
 	// Relayer Factory
 	client, network := test.DockerSetup(t)
 
-	r := relayer.NewBuiltinRelayerFactory(ibc.CosmosRly, zaptest.NewLogger(t),
+	r := test.NewBuiltinRelayerFactory(ibc.CosmosRly, zaptest.NewLogger(t),
 		relayer.CustomDockerImage("ghcr.io/cosmos/relayer", "reece-v2.3.1-ethermint", "100:1000"),
 	).Build(t, client, network)
 
 	ic := test.NewSetup().
-		AddChain(rollapp1).
-		AddChain(dymension).
+		AddRollUp(dymension, rollapp1).
 		AddRelayer(r, "relayer").
 		AddLink(test.InterchainLink{
 			Chain1:  dymension,


### PR DESCRIPTION
Currently, as an result of updating on rollup-e2e-testing, the TestIBCGracePeriodCompliance has some error on it. 
This PR will update it in order to match the lastest rollup-e2e-testing version