### PR TITLE
Add genesis event to all tests that need it

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -25,16 +25,16 @@ jobs:
     strategy:
       matrix:
         tests:
-          - "e2e-test-ibc-success-evm"
+        #  - "e2e-test-ibc-success-evm"
           - "e2e-test-ibc-timeout-evm"
-          - "e2e-test-ibc-grace-period-evm"
-          - "e2e-test-eibc-fulfillment-evm"
-          - "e2e-test-transfer-multi-hop-evm"
-          - "e2e-test-pfm-with-grace-period-evm"
-          - "e2e-test-batch-finalization-evm"
-          - "e2e-test-rollapp-freeze-evm"
-          - "e2e-test-other-rollapp-not-affected-evm"
-          - "e2e-test-rollapp-genesis-event-evm"
+        #  - "e2e-test-ibc-grace-period-evm"
+        #  - "e2e-test-eibc-fulfillment-evm"
+        #  - "e2e-test-transfer-multi-hop-evm"
+        #  - "e2e-test-pfm-with-grace-period-evm"
+        #  - "e2e-test-batch-finalization-evm"
+        #  - "e2e-test-rollapp-freeze-evm"
+        #  - "e2e-test-other-rollapp-not-affected-evm"
+        #  - "e2e-test-rollapp-genesis-event-evm"
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -49,29 +49,3 @@ jobs:
       - name: Rollapp-EVM E2E Tests
         run: |
           make ${{ matrix.tests }}
-  rollapp-wasm:
-    strategy:
-      matrix:
-        tests:
-          - "e2e-test-ibc-success-wasm"
-          - "e2e-test-ibc-timeout-wasm"
-          - "e2e-test-ibc-grace-period-wasm"
-          - "e2e-test-eibc-fulfillment-wasm"
-          - "e2e-test-transfer-multi-hop-wasm"
-          - "e2e-test-pfm-with-grace-period-wasm"
-          - "e2e-test-batch-finalization-wasm"
-          - "e2e-test-rollapp-freeze-wasm"
-          - "e2e-test-other-rollapp-not-affected-wasm"
-      fail-fast: false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: dymensionxyz/e2e-tests
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21.4"
-
-      - name: Rollapp-Wasm E2E Tests
-        run: make ${{ matrix.tests }}

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -25,16 +25,16 @@ jobs:
     strategy:
       matrix:
         tests:
-        #  - "e2e-test-ibc-success-evm"
+          - "e2e-test-ibc-success-evm"
           - "e2e-test-ibc-timeout-evm"
-        #  - "e2e-test-ibc-grace-period-evm"
-        #  - "e2e-test-eibc-fulfillment-evm"
-        #  - "e2e-test-transfer-multi-hop-evm"
-        #  - "e2e-test-pfm-with-grace-period-evm"
-        #  - "e2e-test-batch-finalization-evm"
-        #  - "e2e-test-rollapp-freeze-evm"
-        #  - "e2e-test-other-rollapp-not-affected-evm"
-        #  - "e2e-test-rollapp-genesis-event-evm"
+          - "e2e-test-ibc-grace-period-evm"
+          - "e2e-test-eibc-fulfillment-evm"
+          - "e2e-test-transfer-multi-hop-evm"
+          - "e2e-test-pfm-with-grace-period-evm"
+          - "e2e-test-batch-finalization-evm"
+          - "e2e-test-rollapp-freeze-evm"
+          - "e2e-test-other-rollapp-not-affected-evm"
+          - "e2e-test-rollapp-genesis-event-evm"
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -49,3 +49,29 @@ jobs:
       - name: Rollapp-EVM E2E Tests
         run: |
           make ${{ matrix.tests }}
+  rollapp-wasm:
+    strategy:
+      matrix:
+        tests:
+          - "e2e-test-ibc-success-wasm"
+          - "e2e-test-ibc-timeout-wasm"
+          - "e2e-test-ibc-grace-period-wasm"
+          - "e2e-test-eibc-fulfillment-wasm"
+          - "e2e-test-transfer-multi-hop-wasm"
+          - "e2e-test-pfm-with-grace-period-wasm"
+          - "e2e-test-batch-finalization-wasm"
+          - "e2e-test-rollapp-freeze-wasm"
+          - "e2e-test-other-rollapp-not-affected-wasm"
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: dymensionxyz/e2e-tests
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.4"
+
+      - name: Rollapp-Wasm E2E Tests
+        run: make ${{ matrix.tests }}

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/decentrio/rollup-e2e-testing v0.0.0-20240401062200-380e8b9d21f4
 	github.com/dymensionxyz/dymension-rdk v1.1.0-beta
-	github.com/dymensionxyz/dymension/v3 v3.0.0-rc02.0.20240321090214-067a132551ab
+	github.com/dymensionxyz/dymension/v3 v3.1.0-rc01.0.20240404003005-53ccf8a922fd
 	github.com/evmos/ethermint v0.22.0
 	github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845
 	github.com/stretchr/testify v1.8.4
@@ -101,7 +101,7 @@ require (
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-getter v1.7.0 // indirect
+	github.com/hashicorp/go-getter v1.7.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
@@ -193,4 +193,9 @@ require (
 	modernc.org/strutil v1.1.3 // indirect
 	modernc.org/token v1.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
+)
+
+replace (
+	github.com/osmosis-labs/osmosis/v15 => github.com/dymensionxyz/osmosis/v15 v15.2.0-dymension-v1.1.3
+	github.com/rollkit/celestia-openrpc => github.com/celestiaorg/celestia-openrpc v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQx
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
 github.com/dymensionxyz/dymension-rdk v1.1.0-beta h1:vvKB6Y65aOOyS6inUCmRrSnlph0MmeLAz6EyXzsdbg4=
 github.com/dymensionxyz/dymension-rdk v1.1.0-beta/go.mod h1:WnmIZVAFUjwsLSWlhPu3VtOHeBinLYAK9s5t1OPOL3o=
-github.com/dymensionxyz/dymension/v3 v3.0.0-rc02.0.20240321090214-067a132551ab h1:7w0Hohobe8l+Xa305T4dU2fp4UsubEu2q7/WcPt/VBE=
-github.com/dymensionxyz/dymension/v3 v3.0.0-rc02.0.20240321090214-067a132551ab/go.mod h1:iX4Lsbk0IH+t1RA1WgT9bNNyGqM6blVL5aYwwoKxaCY=
+github.com/dymensionxyz/dymension/v3 v3.1.0-rc01.0.20240404003005-53ccf8a922fd h1:P7Ku9WRopjY7sKSIx4ahwnHjRYOiUDu8hv4uM+Rzyek=
+github.com/dymensionxyz/dymension/v3 v3.1.0-rc01.0.20240404003005-53ccf8a922fd/go.mod h1:3Pfrr8j/BR9ztNKztGfC5PqDiO6CcrzMLCJtFtPEVW4=
 github.com/dymensionxyz/ethermint v0.22.0-dymension-v0.3 h1:iAtAivMtJh2Ublnq2KasC7EIa5/gfsff5EJ7kUlnd9A=
 github.com/dymensionxyz/ethermint v0.22.0-dymension-v0.3/go.mod h1:O2J61ZwM0Vdms6pRa1fb43pwmCuNRctro3AB90WlOc0=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
@@ -580,8 +580,8 @@ github.com/gtank/ristretto255 v0.1.2/go.mod h1:Ph5OpO6c7xKUGROZfWVLiJf9icMDwUeIv
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-getter v1.7.0 h1:bzrYP+qu/gMrL1au7/aDvkoOVGUJpeKBgbqRHACAFDY=
-github.com/hashicorp/go-getter v1.7.0/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
+github.com/hashicorp/go-getter v1.7.1 h1:SWiSWN/42qdpR0MdhaOc/bLR48PLuP1ZQtYLRlM69uY=
+github.com/hashicorp/go-getter v1.7.1/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/tests/eibc_fulfillment_test.go
+++ b/tests/eibc_fulfillment_test.go
@@ -170,6 +170,8 @@ func TestEIBCFulfillment_EVM(t *testing.T) {
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
+	err = testutil.WaitForBlocks(ctx, 5, dymension)
+	require.NoError(t, err)
 
 	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
 
@@ -414,6 +416,8 @@ func TestEIBCFulfillment_Wasm(t *testing.T) {
 	require.NoError(t, err)
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
+	require.NoError(t, err)
+	err = testutil.WaitForBlocks(ctx, 5, dymension)
 	require.NoError(t, err)
 
 	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)

--- a/tests/eibc_fulfillment_test.go
+++ b/tests/eibc_fulfillment_test.go
@@ -173,7 +173,12 @@ func TestEIBCFulfillment_EVM(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 5, dymension)
 	require.NoError(t, err)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channel.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	transferData := ibc.WalletData{
 		Address: marketMakerAddr,
@@ -420,7 +425,12 @@ func TestEIBCFulfillment_Wasm(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 3, dymension)
 	require.NoError(t, err)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channel.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	transferData := ibc.WalletData{
 		Address: marketMakerAddr,

--- a/tests/eibc_fulfillment_test.go
+++ b/tests/eibc_fulfillment_test.go
@@ -171,6 +171,8 @@ func TestEIBCFulfillment_EVM(t *testing.T) {
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
 
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+
 	transferData := ibc.WalletData{
 		Address: marketMakerAddr,
 		Denom:   rollapp1.Config().Denom,
@@ -413,6 +415,8 @@ func TestEIBCFulfillment_Wasm(t *testing.T) {
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
+
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
 
 	transferData := ibc.WalletData{
 		Address: marketMakerAddr,

--- a/tests/eibc_fulfillment_test.go
+++ b/tests/eibc_fulfillment_test.go
@@ -8,19 +8,19 @@ import (
 
 	"cosmossdk.io/math"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
 	test "github.com/decentrio/rollup-e2e-testing"
 	"github.com/decentrio/rollup-e2e-testing/blockdb"
 	"github.com/decentrio/rollup-e2e-testing/cosmos"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/rollapp/dym_rollapp"
-	"github.com/decentrio/rollup-e2e-testing/ibc"
-
 	dymensiontesting "github.com/decentrio/rollup-e2e-testing/dymension"
+	"github.com/decentrio/rollup-e2e-testing/ibc"
 	"github.com/decentrio/rollup-e2e-testing/relayer"
 	"github.com/decentrio/rollup-e2e-testing/testreporter"
 	"github.com/decentrio/rollup-e2e-testing/testutil"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 // This test case verifies the system's behavior when an eIBC packet sent from the rollapp to the hub
@@ -173,7 +173,7 @@ func TestEIBCFulfillment_EVM(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 5, dymension)
 	require.NoError(t, err)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
 
 	transferData := ibc.WalletData{
 		Address: marketMakerAddr,
@@ -417,10 +417,10 @@ func TestEIBCFulfillment_Wasm(t *testing.T) {
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
-	err = testutil.WaitForBlocks(ctx, 5, dymension)
+	err = testutil.WaitForBlocks(ctx, 3, dymension)
 	require.NoError(t, err)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
 
 	transferData := ibc.WalletData{
 		Address: marketMakerAddr,

--- a/tests/frozen_test.go
+++ b/tests/frozen_test.go
@@ -422,15 +422,11 @@ func TestRollAppFreeze_Wasm(t *testing.T) {
 	dymChannel, err := r.GetChannels(ctx, eRep, dymension.Config().ChainID)
 	require.NoError(t, err)
 	require.Equal(t, len(dymChannel), 1)
-
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), dymChannel[0].ChannelID, dymensionUser)
-
 	// Wait a few blocks for relayer to start and for user accounts to be created
 	err = testutil.WaitForBlocks(ctx, 3, dymension, rollapp1)
 	require.NoError(t, err)
 
-	err = testutil.WaitForBlocks(ctx, 1, dymension, rollapp1)
-	require.NoError(t, err)
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), dymChannel[0].ChannelID, dymensionUser)
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -748,9 +744,6 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 	require.NotEmpty(t, channsRollApp2Dym.ChannelID)
 
 	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp1.ChannelID, dymensionUser)
-
-	err = testutil.WaitForBlocks(ctx, 1, dymension, rollapp1)
-	require.NoError(t, err)
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -1158,9 +1151,6 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 	require.NotEmpty(t, channsRollApp2Dym.ChannelID)
 
 	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp1.ChannelID, dymensionUser)
-
-	err = testutil.WaitForBlocks(ctx, 1, dymension, rollapp1)
-	require.NoError(t, err)
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)

--- a/tests/frozen_test.go
+++ b/tests/frozen_test.go
@@ -9,6 +9,9 @@ import (
 
 	"cosmossdk.io/math"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
 	test "github.com/decentrio/rollup-e2e-testing"
 	"github.com/decentrio/rollup-e2e-testing/cosmos"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
@@ -17,8 +20,6 @@ import (
 	"github.com/decentrio/rollup-e2e-testing/relayer"
 	"github.com/decentrio/rollup-e2e-testing/testreporter"
 	"github.com/decentrio/rollup-e2e-testing/testutil"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 const anotherIbcPath = "dymension-demo2"
@@ -184,7 +185,7 @@ func TestRollAppFreeze_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(dymChannel), 1)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), dymChannel[0].ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, dymChannel[0].ChannelID, dymensionUser.KeyName())
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -426,7 +427,7 @@ func TestRollAppFreeze_Wasm(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 3, dymension, rollapp1)
 	require.NoError(t, err)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), dymChannel[0].ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, dymChannel[0].ChannelID, dymensionUser.KeyName())
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -743,7 +744,7 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 	channsRollApp2Dym := channsRollApp2[0]
 	require.NotEmpty(t, channsRollApp2Dym.ChannelID)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp1.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp1.ChannelID, dymensionUser.KeyName())
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -1150,7 +1151,7 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 	channsRollApp2Dym := channsRollApp2[0]
 	require.NotEmpty(t, channsRollApp2Dym.ChannelID)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp1.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp1.ChannelID, dymensionUser.KeyName())
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)

--- a/tests/frozen_test.go
+++ b/tests/frozen_test.go
@@ -916,14 +916,16 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, tx.TxHash, "tx is nil")
 
-	err = testutil.WaitForBlocks(ctx, 100, dymension)
+	// wait until the packet is finalized
+	isFinalized, err := dymension.WaitUntilRollappHeightIsFinalized(ctx, rollapp2.GetChainID(), rollappHeight, 300)
 	require.NoError(t, err)
+	require.True(t, isFinalized)
 
 	// Get updated dym hub ibc denom balance
 	dymUserUpdateBal2, err := dymension.GetBalance(ctx, dymensionUserAddr, rollapp2IbcDenom)
 	require.NoError(t, err)
 
-	require.Equal(t, true, dymUserUpdateBal2.Sub(transferAmount).Equal(dymUserOriginBal2), "dym hub balance did not change")
+	require.Equal(t, true, dymUserUpdateBal2.Equal(dymUserOriginBal2.Add(transferAmount)), "dym hub balance did not change")
 }
 
 // TestOtherRollappNotAffected_Wasm ensure upon freeze gov proposal passed, no updates can be made to the rollapp and not IBC txs are passing and other rollapp works fine.
@@ -1327,14 +1329,19 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, tx.TxHash, "tx is nil")
 
-	err = testutil.WaitForBlocks(ctx, 100, dymension)
+	rollappHeight, err = rollapp2.GetNode().Height(ctx)
 	require.NoError(t, err)
+
+	// wait until the packet is finalized
+	isFinalized, err := dymension.WaitUntilRollappHeightIsFinalized(ctx, rollapp2.GetChainID(), rollappHeight, 300)
+	require.NoError(t, err)
+	require.True(t, isFinalized)
 
 	// Get updated dym hub ibc denom balance
 	dymUserUpdateBal2, err := dymension.GetBalance(ctx, dymensionUserAddr, rollapp2IbcDenom)
 	require.NoError(t, err)
 
-	require.Equal(t, true, dymUserUpdateBal2.Sub(transferAmount).Equal(dymUserOriginBal2), "dym hub balance did not change")
+	require.Equal(t, true, dymUserUpdateBal2.Equal(dymUserOriginBal2.Add(transferAmount)), "dym hub balance did not change")
 }
 
 func GetIBCDenom(counterPartyPort, counterPartyChannel, denom string) string {

--- a/tests/frozen_test.go
+++ b/tests/frozen_test.go
@@ -183,9 +183,14 @@ func TestRollAppFreeze_EVM(t *testing.T) {
 
 	dymChannel, err := r.GetChannels(ctx, eRep, dymension.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, len(dymChannel), 1)
+	require.Equal(t, 1, len(dymChannel))
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, dymChannel[0].ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: dymChannel[0].ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -216,7 +221,7 @@ func TestRollAppFreeze_EVM(t *testing.T) {
 
 	rollapp1Clients, err := r.GetClients(ctx, eRep, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, len(rollapp1Clients), 1)
+	require.Equal(t, 1, len(rollapp1Clients))
 
 	err = dymension.SubmitFraudProposal(
 		ctx, dymensionUser.KeyName(),
@@ -240,12 +245,12 @@ func TestRollAppFreeze_EVM(t *testing.T) {
 	// Check if rollapp has frozen or not
 	rollappParams, err := dymension.QueryRollappParams(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, rollappParams.Rollapp.Frozen, true, "rollapp does not frozen")
+	require.Equal(t, true, rollappParams.Rollapp.Frozen, "rollapp does not frozen")
 
 	// Check rollapp state index not increment
 	latestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, latestIndex.StateIndex.Index, fmt.Sprint(targetIndex), "rollapp state index still increment")
+	require.Equal(t, fmt.Sprint(targetIndex), latestIndex.StateIndex.Index, "rollapp state index still increment")
 
 	// IBC Transfer not working
 	channel, err := ibc.GetTransferChannel(ctx, r, eRep, dymension.Config().ChainID, rollapp1.Config().ChainID)
@@ -259,7 +264,7 @@ func TestRollAppFreeze_EVM(t *testing.T) {
 		rollappUserAddr, r, ibcPath, channel,
 		eRep, ibc.TransferOptions{})
 	require.Error(t, err)
-	require.Equal(t, strings.Contains(err.Error(), "status Frozen"), true)
+	require.Equal(t, true, strings.Contains(err.Error(), "status Frozen"))
 
 	// Compose an IBC transfer and send from rollapp -> dymension
 	err = rollapp1.IBCTransfer(ctx,
@@ -422,12 +427,17 @@ func TestRollAppFreeze_Wasm(t *testing.T) {
 
 	dymChannel, err := r.GetChannels(ctx, eRep, dymension.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, len(dymChannel), 1)
+	require.Equal(t, 1, len(dymChannel))
 	// Wait a few blocks for relayer to start and for user accounts to be created
 	err = testutil.WaitForBlocks(ctx, 3, dymension, rollapp1)
 	require.NoError(t, err)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, dymChannel[0].ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: dymChannel[0].ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -476,12 +486,12 @@ func TestRollAppFreeze_Wasm(t *testing.T) {
 	// Check if rollapp has frozen or not
 	rollappParams, err := dymension.QueryRollappParams(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, rollappParams.Rollapp.Frozen, true, "rollapp does not frozen")
+	require.Equal(t, true, rollappParams.Rollapp.Frozen, "rollapp does not frozen")
 
 	// Check rollapp state index not increment
 	latestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, latestIndex.StateIndex.Index, "2", "rollapp state index still increment")
+	require.Equal(t, "2", latestIndex.StateIndex.Index, "rollapp state index still increment")
 
 	// IBC Transfer not working
 	channel, err := ibc.GetTransferChannel(ctx, r, eRep, dymension.Config().ChainID, rollapp1.Config().ChainID)
@@ -495,7 +505,7 @@ func TestRollAppFreeze_Wasm(t *testing.T) {
 		rollappUserAddr, r, ibcPath, channel,
 		eRep, ibc.TransferOptions{})
 	require.Error(t, err)
-	require.Equal(t, strings.Contains(err.Error(), "status Frozen"), true)
+	require.Equal(t, true, strings.Contains(err.Error(), "status Frozen"))
 
 	err = rollapp1.IBCTransfer(ctx,
 		rollapp1, dymension, transferAmount, rollappUserAddr,
@@ -744,7 +754,12 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 	channsRollApp2Dym := channsRollApp2[0]
 	require.NotEmpty(t, channsRollApp2Dym.ChannelID)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp1.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channDymRollApp1.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -783,7 +798,7 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 
 	dymClients, err := r.GetClients(ctx, eRep, dymension.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, len(dymClients), 2)
+	require.Equal(t, 2, len(dymClients))
 
 	var rollapp1ClientOnDym string
 
@@ -807,12 +822,12 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 	// Check if rollapp1 has frozen or not
 	rollappParams, err := dymension.QueryRollappParams(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, rollappParams.Rollapp.Frozen, true, "rollapp does not frozen")
+	require.Equal(t, true, rollappParams.Rollapp.Frozen, "rollapp does not frozen")
 
 	// Check rollapp1 state index not increment
 	latestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, latestIndex.StateIndex.Index, fmt.Sprint(targetIndex), "rollapp state index still increment")
+	require.Equal(t, fmt.Sprint(targetIndex), latestIndex.StateIndex.Index, "rollapp state index still increment")
 
 	// Compose an IBC transfer and send from dymension -> rollapp
 	transferAmount := math.NewInt(1_000_000)
@@ -889,7 +904,7 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 	rollapp2UserUpdateBal, err := rollapp2.GetBalance(ctx, rollapp2UserAddr, dymToRollapp2IbcDenom)
 	require.NoError(t, err)
 
-	require.Equal(t, rollapp2UserUpdateBal.Sub(transferAmount).Equal(rollapp2UserOriginBal), true, "rollapp balance did not change")
+	require.Equal(t, true, rollapp2UserUpdateBal.Sub(transferAmount).Equal(rollapp2UserOriginBal), "rollapp balance did not change")
 
 	transferData = ibc.WalletData{
 		Address: dymensionUserAddr,
@@ -908,7 +923,7 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 	dymUserUpdateBal2, err := dymension.GetBalance(ctx, dymensionUserAddr, rollapp2IbcDenom)
 	require.NoError(t, err)
 
-	require.Equal(t, dymUserUpdateBal2.Sub(transferAmount).Equal(dymUserOriginBal2), true, "dym hub balance did not change")
+	require.Equal(t, true, dymUserUpdateBal2.Sub(transferAmount).Equal(dymUserOriginBal2), "dym hub balance did not change")
 }
 
 // TestOtherRollappNotAffected_Wasm ensure upon freeze gov proposal passed, no updates can be made to the rollapp and not IBC txs are passing and other rollapp works fine.
@@ -1151,7 +1166,12 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 	channsRollApp2Dym := channsRollApp2[0]
 	require.NotEmpty(t, channsRollApp2Dym.ChannelID)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp1.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channDymRollApp1.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	oldLatestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -1190,7 +1210,7 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 
 	dymClients, err := r.GetClients(ctx, eRep, dymension.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, len(dymClients), 2)
+	require.Equal(t, 2, len(dymClients))
 
 	var rollapp1ClientOnDym string
 
@@ -1213,12 +1233,12 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 	// Check if rollapp1 has frozen or not
 	rollappParams, err := dymension.QueryRollappParams(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, rollappParams.Rollapp.Frozen, true, "rollapp does not frozen")
+	require.Equal(t, true, rollappParams.Rollapp.Frozen, "rollapp does not frozen")
 
 	// Check rollapp1 state index not increment
 	latestIndex, err := dymension.GetNode().QueryLatestStateIndex(ctx, rollapp1.Config().ChainID)
 	require.NoError(t, err)
-	require.Equal(t, latestIndex.StateIndex.Index, fmt.Sprint(targetIndex), "rollapp state index still increment")
+	require.Equal(t, fmt.Sprint(targetIndex), latestIndex.StateIndex.Index, "rollapp state index still increment")
 
 	// Compose an IBC transfer and send from dymension -> rollapp
 	transferAmount := math.NewInt(1_000_000)
@@ -1295,7 +1315,7 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 	rollapp2UserUpdateBal, err := rollapp2.GetBalance(ctx, rollapp2UserAddr, dymToRollapp2IbcDenom)
 	require.NoError(t, err)
 
-	require.Equal(t, rollapp2UserUpdateBal.Sub(transferAmount).Equal(rollapp2UserOriginBal), true, "rollapp balance did not change")
+	require.Equal(t, true, rollapp2UserUpdateBal.Sub(transferAmount).Equal(rollapp2UserOriginBal), "rollapp balance did not change")
 
 	transferData = ibc.WalletData{
 		Address: dymensionUserAddr,
@@ -1314,7 +1334,7 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 	dymUserUpdateBal2, err := dymension.GetBalance(ctx, dymensionUserAddr, rollapp2IbcDenom)
 	require.NoError(t, err)
 
-	require.Equal(t, dymUserUpdateBal2.Sub(transferAmount).Equal(dymUserOriginBal2), true, "dym hub balance did not change")
+	require.Equal(t, true, dymUserUpdateBal2.Sub(transferAmount).Equal(dymUserOriginBal2), "dym hub balance did not change")
 }
 
 func GetIBCDenom(counterPartyPort, counterPartyChannel, denom string) string {

--- a/tests/ibc_grace_period_test.go
+++ b/tests/ibc_grace_period_test.go
@@ -7,6 +7,9 @@ import (
 
 	"cosmossdk.io/math"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
 	test "github.com/decentrio/rollup-e2e-testing"
 	"github.com/decentrio/rollup-e2e-testing/cosmos"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
@@ -15,8 +18,6 @@ import (
 	"github.com/decentrio/rollup-e2e-testing/relayer"
 	"github.com/decentrio/rollup-e2e-testing/testreporter"
 	"github.com/decentrio/rollup-e2e-testing/testutil"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 // TestIBCGracePeriodCompliance ensures that the grace period for transaction finalization is correctly enforced on hub and rollapp.
@@ -169,7 +170,7 @@ func TestIBCGracePeriodCompliance_EVM(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 3, rollapp1)
 	require.NoError(t, err)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
 
 	// Compose an IBC transfer and send from Hub -> rollapp
 	_, err = dymension.SendIBCTransfer(ctx, channel.ChannelID, dymensionUserAddr, transferData, ibc.TransferOptions{})
@@ -382,7 +383,7 @@ func TestIBCGracePeriodCompliance_Wasm(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 3, dymension, rollapp1)
 	require.NoError(t, err)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
 
 	// Compose an IBC transfer and send from Hub -> rollapp
 	_, err = dymension.SendIBCTransfer(ctx, channel.ChannelID, dymensionUserAddr, transferData, ibc.TransferOptions{})

--- a/tests/ibc_grace_period_test.go
+++ b/tests/ibc_grace_period_test.go
@@ -170,7 +170,12 @@ func TestIBCGracePeriodCompliance_EVM(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 3, rollapp1)
 	require.NoError(t, err)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channel.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	// Compose an IBC transfer and send from Hub -> rollapp
 	_, err = dymension.SendIBCTransfer(ctx, channel.ChannelID, dymensionUserAddr, transferData, ibc.TransferOptions{})
@@ -383,7 +388,12 @@ func TestIBCGracePeriodCompliance_Wasm(t *testing.T) {
 	err = testutil.WaitForBlocks(ctx, 3, dymension, rollapp1)
 	require.NoError(t, err)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channel.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	// Compose an IBC transfer and send from Hub -> rollapp
 	_, err = dymension.SendIBCTransfer(ctx, channel.ChannelID, dymensionUserAddr, transferData, ibc.TransferOptions{})

--- a/tests/ibc_grace_period_test.go
+++ b/tests/ibc_grace_period_test.go
@@ -167,6 +167,8 @@ func TestIBCGracePeriodCompliance_EVM(t *testing.T) {
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
 
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+
 	// Compose an IBC transfer and send from Hub -> rollapp
 	_, err = dymension.SendIBCTransfer(ctx, channel.ChannelID, dymensionUserAddr, transferData, ibc.TransferOptions{})
 	require.NoError(t, err)
@@ -375,6 +377,8 @@ func TestIBCGracePeriodCompliance_Wasm(t *testing.T) {
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
+
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
 
 	// Compose an IBC transfer and send from Hub -> rollapp
 	_, err = dymension.SendIBCTransfer(ctx, channel.ChannelID, dymensionUserAddr, transferData, ibc.TransferOptions{})

--- a/tests/ibc_grace_period_test.go
+++ b/tests/ibc_grace_period_test.go
@@ -166,6 +166,8 @@ func TestIBCGracePeriodCompliance_EVM(t *testing.T) {
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
+	err = testutil.WaitForBlocks(ctx, 3, rollapp1)
+	require.NoError(t, err)
 
 	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
 
@@ -376,6 +378,8 @@ func TestIBCGracePeriodCompliance_Wasm(t *testing.T) {
 	}
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
+	require.NoError(t, err)
+	err = testutil.WaitForBlocks(ctx, 3, dymension, rollapp1)
 	require.NoError(t, err)
 
 	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)

--- a/tests/ibc_pfm_test.go
+++ b/tests/ibc_pfm_test.go
@@ -213,7 +213,12 @@ func TestIBCTransferMultiHop_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channDymRollApp.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	t.Run("multihop rollapp->dym->gaia", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)
@@ -452,7 +457,12 @@ func TestIBCTransferMultiHop_Wasm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channDymRollApp.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	t.Run("multihop rollapp->dym->gaia", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)

--- a/tests/ibc_pfm_test.go
+++ b/tests/ibc_pfm_test.go
@@ -9,6 +9,9 @@ import (
 
 	"cosmossdk.io/math"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
 	test "github.com/decentrio/rollup-e2e-testing"
 	"github.com/decentrio/rollup-e2e-testing/cosmos"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
@@ -17,8 +20,6 @@ import (
 	"github.com/decentrio/rollup-e2e-testing/relayer"
 	"github.com/decentrio/rollup-e2e-testing/testreporter"
 	"github.com/decentrio/rollup-e2e-testing/testutil"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestIBCTransferMultiHop_EVM(t *testing.T) {
@@ -212,7 +213,7 @@ func TestIBCTransferMultiHop_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp.ChannelID, dymensionUser.KeyName())
 
 	t.Run("multihop rollapp->dym->gaia", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)
@@ -451,7 +452,7 @@ func TestIBCTransferMultiHop_Wasm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp.ChannelID, dymensionUser.KeyName())
 
 	t.Run("multihop rollapp->dym->gaia", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)

--- a/tests/ibc_pfm_test.go
+++ b/tests/ibc_pfm_test.go
@@ -212,6 +212,8 @@ func TestIBCTransferMultiHop_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp.ChannelID, dymensionUser)
+
 	t.Run("multihop rollapp->dym->gaia", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)
 		secondHopDenom := transfertypes.GetPrefixedDenom(channGaiaDym.PortID, channGaiaDym.ChannelID, firstHopDenom)
@@ -448,6 +450,8 @@ func TestIBCTransferMultiHop_Wasm(t *testing.T) {
 	gaiaOrigBal, err := gaia.GetBalance(ctx, gaiaUserAddr, gaia.Config().Denom)
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
+
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp.ChannelID, dymensionUser)
 
 	t.Run("multihop rollapp->dym->gaia", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)

--- a/tests/ibc_pfm_with_grace_period_test.go
+++ b/tests/ibc_pfm_with_grace_period_test.go
@@ -9,6 +9,9 @@ import (
 
 	"cosmossdk.io/math"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
 	test "github.com/decentrio/rollup-e2e-testing"
 	"github.com/decentrio/rollup-e2e-testing/cosmos"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
@@ -17,8 +20,6 @@ import (
 	"github.com/decentrio/rollup-e2e-testing/relayer"
 	"github.com/decentrio/rollup-e2e-testing/testreporter"
 	"github.com/decentrio/rollup-e2e-testing/testutil"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestIBCPFMWithGracePeriod_EVM(t *testing.T) {
@@ -236,7 +237,7 @@ func TestIBCPFMWithGracePeriod_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp.ChannelID, dymensionUser.KeyName())
 
 	t.Run("multihop rollapp->dym->gaia, funds received on gaia after grace period", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)
@@ -516,7 +517,7 @@ func TestIBCPFMWithGracePeriod_Wasm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp.ChannelID, dymensionUser.KeyName())
 
 	t.Run("multihop rollapp->dym->gaia, funds received on gaia after grace period", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)

--- a/tests/ibc_pfm_with_grace_period_test.go
+++ b/tests/ibc_pfm_with_grace_period_test.go
@@ -237,7 +237,12 @@ func TestIBCPFMWithGracePeriod_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channDymRollApp.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	t.Run("multihop rollapp->dym->gaia, funds received on gaia after grace period", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)
@@ -517,7 +522,12 @@ func TestIBCPFMWithGracePeriod_Wasm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channDymRollApp.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channDymRollApp.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	t.Run("multihop rollapp->dym->gaia, funds received on gaia after grace period", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)

--- a/tests/ibc_pfm_with_grace_period_test.go
+++ b/tests/ibc_pfm_with_grace_period_test.go
@@ -236,6 +236,8 @@ func TestIBCPFMWithGracePeriod_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
 
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp.ChannelID, dymensionUser)
+
 	t.Run("multihop rollapp->dym->gaia, funds received on gaia after grace period", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)
 		secondHopDenom := transfertypes.GetPrefixedDenom(channGaiaDym.PortID, channGaiaDym.ChannelID, firstHopDenom)
@@ -513,6 +515,8 @@ func TestIBCPFMWithGracePeriod_Wasm(t *testing.T) {
 	gaiaOrigBal, err := gaia.GetBalance(ctx, gaiaUserAddr, gaia.Config().Denom)
 	require.NoError(t, err)
 	require.Equal(t, walletAmount, gaiaOrigBal)
+
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channDymRollApp.ChannelID, dymensionUser)
 
 	t.Run("multihop rollapp->dym->gaia, funds received on gaia after grace period", func(t *testing.T) {
 		firstHopDenom := transfertypes.GetPrefixedDenom(channDymRollApp.PortID, channDymRollApp.ChannelID, rollapp1.Config().Denom)

--- a/tests/ibc_timeout_test.go
+++ b/tests/ibc_timeout_test.go
@@ -193,8 +193,8 @@ func TestIBCTransferTimeout_EVM(t *testing.T) {
 	rollappIBCDenom := transfertypes.ParseDenomTrace(rollappTokenDenom).IBCDenom()
 
 	// Assert funds were returned to the sender after the timeout has occured
-	testutil.AssertBalance(t, ctx, rollapp1, rollappUserAddr, rollapp1.Config().Denom, walletAmount)
 	testutil.AssertBalance(t, ctx, dymension, dymensionUserAddr, rollappIBCDenom, math.NewInt(0))
+	testutil.AssertBalance(t, ctx, rollapp1, rollappUserAddr, rollapp1.Config().Denom, walletAmount)
 
 	channel, err = ibc.GetTransferChannel(ctx, r, eRep, rollapp1.Config().ChainID, dymension.Config().ChainID)
 	require.NoError(t, err)

--- a/tests/ibc_timeout_test.go
+++ b/tests/ibc_timeout_test.go
@@ -160,7 +160,12 @@ func TestIBCTransferTimeout_EVM(t *testing.T) {
 	channel, err := ibc.GetTransferChannel(ctx, r, eRep, dymension.Config().ChainID, rollapp1.Config().ChainID)
 	require.NoError(t, err)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channel.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	transferData := ibc.WalletData{
 		Address: dymensionUserAddr,
@@ -379,7 +384,12 @@ func TestIBCTransferTimeout_Wasm(t *testing.T) {
 	channel, err := ibc.GetTransferChannel(ctx, r, eRep, dymension.Config().ChainID, rollapp1.Config().ChainID)
 	require.NoError(t, err)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channel.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	transferData := ibc.WalletData{
 		Address: dymensionUserAddr,

--- a/tests/ibc_timeout_test.go
+++ b/tests/ibc_timeout_test.go
@@ -158,6 +158,11 @@ func TestIBCTransferTimeout_EVM(t *testing.T) {
 	channel, err := ibc.GetTransferChannel(ctx, r, eRep, dymension.Config().ChainID, rollapp1.Config().ChainID)
 	require.NoError(t, err)
 
+	err = r.StartRelayer(ctx, eRep, ibcPath)
+	require.NoError(t, err)
+
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+
 	transferData := ibc.WalletData{
 		Address: dymensionUserAddr,
 		Denom:   rollapp1.Config().Denom,
@@ -175,9 +180,6 @@ func TestIBCTransferTimeout_EVM(t *testing.T) {
 	require.NoError(t, err)
 	// Assert balance was updated on the rollapp
 	testutil.AssertBalance(t, ctx, rollapp1, rollappUserAddr, rollapp1.Config().Denom, walletAmount.Sub(transferData.Amount))
-
-	err = r.StartRelayer(ctx, eRep, ibcPath)
-	require.NoError(t, err)
 
 	err = testutil.WaitForBlocks(ctx, 5, dymension)
 	require.NoError(t, err)
@@ -375,6 +377,11 @@ func TestIBCTransferTimeout_Wasm(t *testing.T) {
 	channel, err := ibc.GetTransferChannel(ctx, r, eRep, dymension.Config().ChainID, rollapp1.Config().ChainID)
 	require.NoError(t, err)
 
+	err = r.StartRelayer(ctx, eRep, ibcPath)
+	require.NoError(t, err)
+
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+
 	transferData := ibc.WalletData{
 		Address: dymensionUserAddr,
 		Denom:   rollapp1.Config().Denom,
@@ -392,9 +399,6 @@ func TestIBCTransferTimeout_Wasm(t *testing.T) {
 	require.NoError(t, err)
 	// Assert balance was updated on the rollapp
 	testutil.AssertBalance(t, ctx, rollapp1, rollappUserAddr, rollapp1.Config().Denom, walletAmount.Sub(transferData.Amount))
-
-	err = r.StartRelayer(ctx, eRep, ibcPath)
-	require.NoError(t, err)
 
 	err = testutil.WaitForBlocks(ctx, 5, dymension)
 	require.NoError(t, err)

--- a/tests/ibc_transfer_test.go
+++ b/tests/ibc_transfer_test.go
@@ -149,6 +149,8 @@ func TestIBCTransferSuccess_EVM(t *testing.T) {
 		},
 	)
 
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+
 	// Compose an IBC transfer and send from dymension -> rollapp
 	transferAmount := math.NewInt(1_000_000)
 
@@ -327,6 +329,8 @@ func TestIBCTransferSuccess_Wasm(t *testing.T) {
 			}
 		},
 	)
+
+	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
 
 	// Compose an IBC transfer and send from dymension -> rollapp
 	transferAmount := math.NewInt(1_000_000)

--- a/tests/ibc_transfer_test.go
+++ b/tests/ibc_transfer_test.go
@@ -140,6 +140,9 @@ func TestIBCTransferSuccess_EVM(t *testing.T) {
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
+	err = testutil.WaitForBlocks(ctx, 3, dymension, rollapp1)
+	require.NoError(t, err)
+
 	t.Cleanup(
 		func() {
 			err := r.StopRelayer(ctx, eRep)
@@ -321,6 +324,9 @@ func TestIBCTransferSuccess_Wasm(t *testing.T) {
 
 	err = r.StartRelayer(ctx, eRep, ibcPath)
 	require.NoError(t, err)
+	err = testutil.WaitForBlocks(ctx, 3, dymension, rollapp1)
+	require.NoError(t, err)
+
 	t.Cleanup(
 		func() {
 			err := r.StopRelayer(ctx, eRep)

--- a/tests/ibc_transfer_test.go
+++ b/tests/ibc_transfer_test.go
@@ -153,7 +153,12 @@ func TestIBCTransferSuccess_EVM(t *testing.T) {
 		},
 	)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channel.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	// Compose an IBC transfer and send from dymension -> rollapp
 	transferAmount := math.NewInt(1_000_000)
@@ -337,7 +342,12 @@ func TestIBCTransferSuccess_Wasm(t *testing.T) {
 		},
 	)
 
-	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
+	rollapp := rollappParam{
+		rollappID: rollapp1.Config().ChainID,
+		channelID: channel.ChannelID,
+		userKey:   dymensionUser.KeyName(),
+	}
+	triggerHubGenesisEvent(t, dymension, rollapp)
 
 	// Compose an IBC transfer and send from dymension -> rollapp
 	transferAmount := math.NewInt(1_000_000)

--- a/tests/ibc_transfer_test.go
+++ b/tests/ibc_transfer_test.go
@@ -7,6 +7,9 @@ import (
 
 	"cosmossdk.io/math"
 	transfertypes "github.com/cosmos/ibc-go/v6/modules/apps/transfer/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
 	test "github.com/decentrio/rollup-e2e-testing"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/rollapp/dym_rollapp"
@@ -14,8 +17,6 @@ import (
 	"github.com/decentrio/rollup-e2e-testing/relayer"
 	"github.com/decentrio/rollup-e2e-testing/testreporter"
 	"github.com/decentrio/rollup-e2e-testing/testutil"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 const ibcPath = "dymension-demo"
@@ -152,7 +153,7 @@ func TestIBCTransferSuccess_EVM(t *testing.T) {
 		},
 	)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
 
 	// Compose an IBC transfer and send from dymension -> rollapp
 	transferAmount := math.NewInt(1_000_000)
@@ -336,7 +337,7 @@ func TestIBCTransferSuccess_Wasm(t *testing.T) {
 		},
 	)
 
-	triggerGenesisEvent(t, dymension, rollapp1.GetChainID(), channel.ChannelID, dymensionUser)
+	triggerHubGenesisEvent(t, dymension, rollapp1.Config().ChainID, channel.ChannelID, dymensionUser.KeyName())
 
 	// Compose an IBC transfer and send from dymension -> rollapp
 	transferAmount := math.NewInt(1_000_000)

--- a/tests/rollapp_genesis_event_test.go
+++ b/tests/rollapp_genesis_event_test.go
@@ -175,7 +175,7 @@ func TestRollappGenesisEvent_EVM(t *testing.T) {
 	denommetadata, err := dymension.GetNode().QueryDenomMetadata(ctx, genesisCoin.Denom)
 	require.NoError(t, err)
 
-	require.Equal(t, denommetadata.Description, fmt.Sprintf("auto-generated metadata for %s from rollapp %s", genesisCoin.Denom, rollapp1.GetChainID()))
+	require.Equal(t, fmt.Sprintf("auto-generated metadata for %s from rollapp %s", genesisCoin.Denom, rollapp1.GetChainID()), denommetadata.Description)
 	require.Equal(t, denommetadata.Base, genesisCoin.Denom)
 	denomUnits := []cosmos.DenomUnit{
 		{
@@ -189,8 +189,8 @@ func TestRollappGenesisEvent_EVM(t *testing.T) {
 			Aliases:  []string{},
 		},
 	}
-	require.Equal(t, denommetadata.DenomUnits, denomUnits)
-	require.Equal(t, denommetadata.Display, "rax")
-	require.Equal(t, denommetadata.Symbol, "URAX")
-	require.Equal(t, denommetadata.Name, fmt.Sprintf("%s %s", rollapp1.GetChainID(), rollapp1.Config().Denom))
+	require.Equal(t, denomUnits, denommetadata.DenomUnits)
+	require.Equal(t, "rax", denommetadata.Display)
+	require.Equal(t, "URAX", denommetadata.Symbol)
+	require.Equal(t, fmt.Sprintf("%s %s", rollapp1.GetChainID(), rollapp1.Config().Denom), denommetadata.Name)
 }

--- a/tests/rollapp_genesis_event_test.go
+++ b/tests/rollapp_genesis_event_test.go
@@ -7,6 +7,9 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
 	test "github.com/decentrio/rollup-e2e-testing"
 	"github.com/decentrio/rollup-e2e-testing/cosmos"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
@@ -15,8 +18,6 @@ import (
 	"github.com/decentrio/rollup-e2e-testing/relayer"
 	"github.com/decentrio/rollup-e2e-testing/testreporter"
 	"github.com/decentrio/rollup-e2e-testing/testutil"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 // TestRollappGenesisEvent_EVM ensure that genesis event triggered in both rollapp evm and dymension hub
@@ -128,7 +129,7 @@ func TestRollappGenesisEvent_EVM(t *testing.T) {
 	dymensionUserAddr := dymensionUser.FormattedAddress()
 	rollappUserAddr := rollappUser.FormattedAddress()
 
-	registerGenesisEventTriggerer(t, dymension, dymensionUser, "rollapp", "DeployerWhitelist")
+	registerGenesisEventTriggerer(t, dymension.CosmosChain, dymensionUser.KeyName(), dymensionUserAddr, "rollapp", "DeployerWhitelist")
 
 	channel, err := ibc.GetTransferChannel(ctx, r, eRep, dymension.Config().ChainID, rollapp1.Config().ChainID)
 	require.NoError(t, err)
@@ -153,7 +154,7 @@ func TestRollappGenesisEvent_EVM(t *testing.T) {
 
 	testutil.AssertBalance(t, ctx, dymension, validatorAddr, genesisCoin.Denom, genesisCoin.Amount)
 
-	registerGenesisEventTriggerer(t, dymension, dymensionUser, "hubgenesis", "GenesisTriggererWhitelist")
+	registerGenesisEventTriggerer(t, rollapp1.CosmosChain, rollappUser.KeyName(), rollappUserAddr, "hubgenesis", "GenesisTriggererWhitelist")
 
 	hubgenesisMAcc, err := rollapp1.Validators[0].QueryModuleAccount(ctx, "hubgenesis")
 	require.NoError(t, err)

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -10,11 +10,12 @@ import (
 
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/x/params/client/utils"
+	"github.com/icza/dyno"
+	"github.com/stretchr/testify/require"
+
 	"github.com/decentrio/rollup-e2e-testing/cosmos"
 	"github.com/decentrio/rollup-e2e-testing/cosmos/hub/dym_hub"
 	"github.com/decentrio/rollup-e2e-testing/ibc"
-	"github.com/icza/dyno"
-	"github.com/stretchr/testify/require"
 
 	hubgenesis "github.com/dymensionxyz/dymension-rdk/x/hub-genesis/types"
 	eibc "github.com/dymensionxyz/dymension/v3/x/eibc/types"
@@ -393,38 +394,38 @@ func modifyDymensionGenesis(genesisKV []cosmos.GenesisKV) func(ibc.ChainConfig, 
 	}
 }
 
-func registerGenesisEventTriggerer(t *testing.T, dymension *dym_hub.DymHub, user ibc.Wallet, module, param string) {
+func triggerHubGenesisEvent(t *testing.T, dymension *dym_hub.DymHub, rollappID, channelID, userKey string) {
 	ctx := context.Background()
 	keyDir := dymension.GetRollApps()[0].GetSequencerKeyDir()
 	sequencerAddr, err := dymension.AccountKeyBech32WithKeyDir(ctx, "sequencer", keyDir)
 	require.NoError(t, err)
-	deployerWhitelistParams := json.RawMessage(fmt.Sprintf(`[{"address":"%s"}]`, sequencerAddr))
-	propTx, err := dymension.ParamChangeProposal(ctx, user.KeyName(), &utils.ParamChangeProposalJSON{
+	registerGenesisEventTriggerer(t, dymension.CosmosChain, userKey, sequencerAddr, "rollapp", "DeployerWhitelist")
+	err = dymension.GetNode().TriggerGenesisEvent(ctx, "sequencer", rollappID, channelID, keyDir)
+	require.NoError(t, err)
+}
+
+func registerGenesisEventTriggerer(t *testing.T, targetChain *cosmos.CosmosChain, userKey, address, module, param string) {
+	ctx := context.Background()
+	deployerWhitelistParams := json.RawMessage(fmt.Sprintf(`[{"address":"%s"}]`, address))
+	propTx, err := targetChain.ParamChangeProposal(ctx, userKey, &utils.ParamChangeProposalJSON{
 		Title:       "Add new deployer to whitelist",
 		Description: "Add current user addr to the deployer whitelist",
 		Changes: utils.ParamChangesJSON{
 			utils.NewParamChangeJSON(module, param, deployerWhitelistParams),
 		},
-		Deposit: "500000000000" + dymension.Config().Denom, // greater than min deposit
+		Deposit: "500000000000" + targetChain.Config().Denom, // greater than min deposit
 	})
 	require.NoError(t, err)
 
-	err = dymension.VoteOnProposalAllValidators(ctx, propTx.ProposalID, cosmos.ProposalVoteYes)
+	err = targetChain.VoteOnProposalAllValidators(ctx, propTx.ProposalID, cosmos.ProposalVoteYes)
 	require.NoError(t, err, "failed to submit votes")
 
-	height, err := dymension.Height(ctx)
+	height, err := targetChain.Height(ctx)
 	require.NoError(t, err, "error fetching height")
-	_, err = cosmos.PollForProposalStatus(ctx, dymension.CosmosChain, height, height+20, propTx.ProposalID, cosmos.ProposalStatusPassed)
+	_, err = cosmos.PollForProposalStatus(ctx, targetChain, height, height+30, propTx.ProposalID, cosmos.ProposalStatusPassed)
 	require.NoError(t, err, "proposal status did not change to passed")
 
-	new_params, err := dymension.QueryParam(ctx, "rollapp", "DeployerWhitelist")
+	new_params, err := targetChain.QueryParam(ctx, module, param)
 	require.NoError(t, err)
 	require.Equal(t, new_params.Value, string(deployerWhitelistParams))
-}
-
-func triggerGenesisEvent(t *testing.T, dymension *dym_hub.DymHub, rollappID, channelID string, user ibc.Wallet) {
-	registerGenesisEventTriggerer(t, dymension, user, "rollapp", "DeployerWhitelist")
-	keyDir := dymension.GetRollApps()[0].GetSequencerKeyDir()
-	err := dymension.GetNode().TriggerGenesisEvent(context.Background(), "sequencer", rollappID, channelID, keyDir)
-	require.NoError(t, err)
 }


### PR DESCRIPTION
We now check if `rollapp.ChannelID!=channelID` on IBC transfers, so each test doin an IBC transfer needs to trigger the genesis event first