### PR TITLE
fix: retrieve current rollapp height

### DIFF
--- a/tests/frozen_test.go
+++ b/tests/frozen_test.go
@@ -916,6 +916,9 @@ func TestOtherRollappNotAffected_EVM(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, tx.TxHash, "tx is nil")
 
+	rollappHeight, err = rollapp2.Height(ctx)
+	require.NoError(t, err)
+
 	// wait until the packet is finalized
 	isFinalized, err := dymension.WaitUntilRollappHeightIsFinalized(ctx, rollapp2.GetChainID(), rollappHeight, 300)
 	require.NoError(t, err)
@@ -1329,7 +1332,7 @@ func TestOtherRollappNotAffected_Wasm(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, tx.TxHash, "tx is nil")
 
-	rollappHeight, err = rollapp2.GetNode().Height(ctx)
+	rollappHeight, err = rollapp2.Height(ctx)
 	require.NoError(t, err)
 
 	// wait until the packet is finalized


### PR DESCRIPTION
Retrieve current rollapp height straight after IBC transfer send. It was using wrong height reference earlier.