### PR TITLE
fix: fix bump `dymint` to `v1.2.0-rc01`

### DIFF
--- a/tests/ibc_finalize_block_test.go
+++ b/tests/ibc_finalize_block_test.go
@@ -35,7 +35,7 @@ func TestDymFinalizeBlock_OnRecvPacket_EVM(t *testing.T) {
 	gas_price_rollapp1 := "0adym"
 	maxIdleTime1 := "3s"
 	maxProofTime := "500ms"
-	configFileOverrides := overridesDymintToml(settlement_layer_rollapp1, settlement_node_address, rollapp1_id, gas_price_rollapp1, maxIdleTime1, maxProofTime, "100s")
+	configFileOverrides := overridesDymintToml(settlement_layer_rollapp1, settlement_node_address, rollapp1_id, gas_price_rollapp1, maxIdleTime1, maxProofTime, "30s")
 
 	modifyGenesisKV := append(
 		rollappEVMGenesisKV,
@@ -194,7 +194,7 @@ func TestDymFinalizeBlock_OnRecvPacket_EVM(t *testing.T) {
 	// Make sure that the ack contains error
 	require.True(t, bytes.Contains(ack.Acknowledgement, []byte("error")))
 
-	err = testutil.WaitForBlocks(ctx, 40, dymension, rollapp1)
+	err = testutil.WaitForBlocks(ctx, 50, dymension, rollapp1)
 	require.NoError(t, err)
 
 	testutil.AssertBalance(t, ctx, dymension, dymensionUserAddr, dymension.Config().Denom, walletAmount)


### PR DESCRIPTION
- This pr helps to solve the fail of e2e test when we pump the `dymint` to `v1.2.0-rc01`